### PR TITLE
feature: replace shelve with configparser

### DIFF
--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -51,6 +51,6 @@ The following are features that should be added to this project:
 8. (OK) Support kconfig-merger
 9. (OK) Support disabling build log output
 10. Prettify logging: add colored output and option to log to file
-11. Replace the shelve module: use .ini file instead
+11. (OK) Replace the shelve module: use .ini file instead
 12. Add support for custom Make options on `NuttXBuilder.build`
 13. (Partial support) Support extra flags on configure.sh script

--- a/docs/source/how_it_works.md
+++ b/docs/source/how_it_works.md
@@ -7,11 +7,11 @@ When `start` option is called, the "environment" is prepared. This means things:
 - An environment file is created which is used to store some information
 - The path to the NuttX repository is added to the env file
 - The path to the NuttX Application repository is also added to the env file
+- The build tool is added to the env file (Make or CMake)
 
 This env file will be used by the tool to locate the repositories.
-In the future (as a TO-DO task), the same file (which may be changed to a .ini file)
-could be used to store other stuff, such as out-of-tree repositories and path
-to toolchains.
+In the future (as a TO-DO task), the same file could be used to store other information,
+such as out-of-tree repositories and path to toolchains.
 
 Once the environment file is setup, a `NuttXBuilder` instance is created and
 it sets up the NuttX environment by checking if the repository is valid

--- a/ntxbuild/build.py
+++ b/ntxbuild/build.py
@@ -185,9 +185,10 @@ class NuttXBuilder:
                 - bool: True if environment is valid, False otherwise.
                 - str: Error message if validation failed, empty string if valid.
         """
-        logger.info(
+        logger.debug(
             f"Validating NuttX environment: nuttx_dir={self.nuttx_path},"
-            f" apps_dir={self.apps_path}"
+            f" apps_dir={self.apps_path}, "
+            f"nuttxspace_path={self.nuttxspace_path}"
         )
 
         # Check for NuttX environment files

--- a/ntxbuild/env_data.py
+++ b/ntxbuild/env_data.py
@@ -1,98 +1,97 @@
+import configparser
 import logging
-import shelve
+import os
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional
 
 # Get logger for this module
 logger = logging.getLogger("ntxbuild.env_data")
 
 
-def get_env_file_path() -> Path:
-    """Get the path to the .ntxenv file in the current working directory.
-
-    Returns:
-        Path: Path to the .ntxenv file in the current working directory.
-    """
-    return Path.cwd() / ".ntxenv"
-
-
-def save_ntx_env(nuttxspace_folder: str, nuttx_folder: str, apps_folder: str) -> None:
-    """Save NuttX environment configuration to .ntxenv file.
-
-    Saves the NuttX workspace, OS directory, and apps directory paths
-    to a shelve database file (.ntxenv) in the current working directory.
+def save_ntx_env(
+    nuttxspace_path: Path, nuttx_dir: str, apps_dir: str, build_tool: str = "make"
+) -> None:
+    """Save environment configuration to an INI file.
 
     Args:
-        nuttxspace_folder: Path to the NuttX workspace directory.
-        nuttx_folder: Name of the NuttX OS directory.
-        apps_folder: Name of the NuttX apps directory.
+        nuttxspace_path: Path to the NuttX workspace directory.
+        nuttx_dir: Name of the NuttX OS directory.
+        apps_dir: Name of the NuttX apps directory.
+        build_tool: Build tool name (default: 'make').
     """
-    env_file = get_env_file_path()
-
-    with shelve.open(str(env_file)) as db:
-        db["nuttx_folder"] = nuttx_folder
-        db["apps_folder"] = apps_folder
-        db["nuttxspace_folder"] = nuttxspace_folder
-
-
-def load_ntx_env() -> Optional[Tuple[str, str, str]]:
-    """Load NuttX environment configuration from .ntxenv file.
-
-    Loads the saved NuttX environment configuration from the .ntxenv
-    shelve database file in the current working directory.
-
-    Returns:
-        Optional[Tuple[str, str, str]]: A tuple containing:
-            - Path to the NuttX workspace directory
-            - Name of the NuttX OS directory
-            - Name of the NuttX apps directory
-            - Or, returns None if the file doesn't exist, is invalid, or
-              contains incomplete data.
-    """
-    env_file = get_env_file_path()
-
-    if not env_file.exists():
-        return None
+    env_file = nuttxspace_path / ".ntxenv"
+    config = configparser.ConfigParser()
+    config["general"] = {
+        "nuttxspace_path": str(nuttxspace_path),
+        "nuttx_dir": nuttx_dir,
+        "apps_dir": apps_dir,
+        "build_tool": build_tool,
+    }
 
     try:
-        with shelve.open(str(env_file)) as db:
-            nuttx_folder = db.get("nuttx_folder")
-            apps_folder = db.get("apps_folder")
-            nuttxspace_folder = db.get("nuttxspace_folder")
-
-            if nuttx_folder and apps_folder and nuttxspace_folder:
-                return nuttxspace_folder, nuttx_folder, apps_folder
-            return None
+        with env_file.open("w", encoding="utf-8") as f:
+            config.write(f)
     except Exception:
+        logger.exception("Failed to write environment file: %s", env_file)
+
+
+def load_ntx_env(nuttxspace_path: Path) -> Optional[Dict[str, object]]:
+    """Load environment configuration from the INI file and return a dict.
+
+    Args:
+        nuttxspace_path: Path to the NuttX workspace directory.
+
+    Returns a dictionary with keys:
+      - 'nuttxspace_path' (Path)
+      - 'nuttx_dir' (str)
+      - 'apps_dir' (str)
+      - 'build_tool' (str)
+
+    Returns None if the file is missing or invalid.
+    """
+    # Change into the nuttxspace directory
+    os.chdir(nuttxspace_path)
+
+    env_file = nuttxspace_path / ".ntxenv"
+    if not env_file.exists():
+        raise FileNotFoundError(f"Environment file does not exist: {env_file}")
+
+    config = configparser.ConfigParser()
+    try:
+        config.read(env_file, encoding="utf-8")
+    except Exception:
+        raise RuntimeError(f"Failed to read environment file: {env_file}")
+
+    if "general" not in config:
+        return None
+
+    section = config["general"]
+    try:
+        nuttxspace = section.get("nuttxspace_path")
+        nuttx_dir = section.get("nuttx_dir")
+        apps_dir = section.get("apps_dir")
+        build_tool = section.get("build_tool", "make")
+
+        if not (nuttxspace and nuttx_dir and apps_dir):
+            return None
+
+        return {
+            "nuttxspace_path": Path(nuttxspace),
+            "nuttx_dir": nuttx_dir,
+            "apps_dir": apps_dir,
+            "build_tool": build_tool,
+        }
+    except Exception:
+        logger.exception("Invalid environment file format: %s", env_file)
         return None
 
 
-def clear_ntx_env() -> None:
-    """Clear the NuttX environment configuration file.
-
-    Deletes the .ntxenv file from the current working directory if it
-    exists. This operation is safe and will not raise an exception if
-    the file doesn't exist.
-    """
-    env_file = get_env_file_path()
-    logger.debug(f"Clearing NuttX environment configuration file: {env_file}")
-    if env_file.exists():
-        try:
+def clear_ntx_env(nuttxspace_path: Path) -> None:
+    """Remove the environment INI file if it exists."""
+    env_file = nuttxspace_path / ".ntxenv"
+    logger.debug("Clearing NuttX environment configuration file: %s", env_file)
+    try:
+        if env_file.exists():
             env_file.unlink()
-        except Exception:
-            pass
-
-
-def has_ntx_env() -> bool:
-    """Check if .ntxenv file exists and contains valid configuration.
-
-    Verifies that the .ntxenv file exists and can be successfully loaded
-    with all required configuration values (workspace, NuttX directory,
-    and apps directory).
-
-    Returns:
-        bool: True if valid configuration exists, False otherwise.
-            Returns False if the file doesn't exist, is corrupted, or
-            contains incomplete data.
-    """
-    return load_ntx_env() is not None
+    except Exception:
+        logger.exception("Failed to remove environment file: %s", env_file)

--- a/ntxbuild/utils.py
+++ b/ntxbuild/utils.py
@@ -247,7 +247,7 @@ def run_curses_command(
 def find_nuttx_root(start_path: Path, nuttx_name: str, apps_name: str) -> Optional[str]:
     """Find the NuttX root directory.
 
-    Searches upward from the start path to find a directory containing
+    Searches UPWARD from the start path to find a directory containing
     both the NuttX OS directory and the NuttX Apps directory.
 
     Args:
@@ -267,6 +267,11 @@ def find_nuttx_root(start_path: Path, nuttx_name: str, apps_name: str) -> Option
         f"Search NuttX root dir in {start_path} for {nuttx_name} and {apps_name}"
     )
     path = start_path.resolve()
+    logger.debug(f"Starting search from {path}")
+
+    if (path / nuttx_name).exists() and (path / apps_name).exists():
+        logger.debug(f"Already on nuttxspace root directory {path}")
+        return path
 
     while path != path.parent:
         if (path / nuttx_name).exists() and (path / apps_name).exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,17 @@ def test_start(nuttxspace_path):
     assert result.exit_code == 0
 
 
+def test_start_from_different_directory(nuttxspace_path):
+    os.chdir(nuttxspace_path / "nuttx")
+
+    runner = CliRunner()
+    result = runner.invoke(start, ["sim", "nshhhh"])
+    assert result.exit_code != 0
+
+    result = runner.invoke(start, ["sim", "nsh"])
+    assert result.exit_code == 0
+
+
 def test_build_and_clean(nuttxspace_path):
     os.chdir(nuttxspace_path)
 


### PR DESCRIPTION
Replaces shelve module with configparser.
We now use a .ini file which is human readable and easy to work on.

Also fixes some logic on the use of this file.