### PR TITLE
documentation: update to new API and update Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ such as make, kconfig-tweak, menuconfig and most used bash scripts (such as conf
 This tool provides a command line interface that supports NuttX configuration and building,
 while also providing a Python API that allows you to script your builds.
 
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Linux](https://img.shields.io/badge/platform-Linux-lightgrey.svg)](https://www.linux.org/)
 
 ## Features
 
 - **Environment Management**: Automatic NuttX workspace detection and configuration
+- **Python API**: API `ntxbuild` available for building NuttX using Python scripts
 - **Parallel Builds**: Support for multi-threaded builds with isolated workspaces
 - **Real-time Output**: Live build progress with proper ANSI escape sequence handling
 - **Configuration Management**: Kconfig integration for easy system configuration
@@ -23,9 +24,10 @@ while also providing a Python API that allows you to script your builds.
 
 ## Requirements
 
-- **Python 3.9+**
+- **Python 3.10+**
 - **NuttX** source code and applications
 - **Make** and standard build tools required by NuttX RTOS
+- **CMake** supported but optional
 
 ## Installation
 

--- a/docs/source/api_examples.md
+++ b/docs/source/api_examples.md
@@ -6,18 +6,27 @@ It allows the use of Python scripts to execute the same commands available
 to the command line, such as: configuring repository, building, creating
 workspace and others, with complete access to stdout, stderr and return codes.
 
-## Configuring and Building
-This examples shows how to setup and build a NuttX binary using only the Python API.
-The script is executed from inside the `nuttxspace`.
+## Configuring and Building (Make)
+This example shows how to set up and build a NuttX binary using the Python API.
+Choose between the `MakeBuilder` (traditional Makefile-based workflow) or
+the `CMakeBuilder` (CMake-based workflow). The script below demonstrates the
+`MakeBuilder` usage. Execute the script from inside the `nuttxspace`.
+
+```{note}
+Makefiles are supported by default on all boards, while CMakeLists is partially
+available.
+```
 
 ```python
 from pathlib import Path
-from ntxbuild.build import NuttXBuilder
+from ntxbuild.build import MakeBuilder
 
 current_dir = Path.cwd()
 
-builder = NuttXBuilder(current_dir, "nuttx", "nuttx-apps")
-setup_result = builder.setup_nuttx("sim", "nsh")
+# Use the Makefile-based builder
+builder = MakeBuilder(current_dir, "nuttx", "nuttx-apps")
+# Initialize the board/defconfig (returns exit code)
+setup_result = builder.initialize("sim", "nsh")
 
 # Execute the build with 10 parallel jobs
 builder.build(parallel=10)
@@ -26,18 +35,48 @@ builder.build(parallel=10)
 builder.distclean()
 ```
 
-## Apply custom options
-ntxbuild allows you to set Kconfig options through the ConfigManager.
+## CMake-based workflow (CMakeBuilder)
+If you prefer a CMake-driven workflow, use `CMakeBuilder`. Key differences:
+
+- **Build system**: `MakeBuilder` drives the traditional `configure.sh` + `make` flow, while
+    `CMakeBuilder` configures and builds using `cmake` (the CMake build directory is used).
+- **Build directory**: `CMakeBuilder` uses a `build` directory (default) and typically
+    uses the Ninja generator by default; `MakeBuilder` builds in-tree using Makefiles.
+- **Distclean**: `MakeBuilder.distclean()` is available and removes generated files. `CMakeBuilder.distclean()`
+    is not supported and will raise a `RuntimeError` (use `clean()` instead).
+
+Example:
 
 ```python
 from pathlib import Path
-from ntxbuild.build import NuttXBuilder
+from ntxbuild.build import CMakeBuilder
+
+current_dir = Path.cwd()
+
+# Use the CMake-based builder
+cmake_builder = CMakeBuilder(current_dir, "nuttx", "nuttx-apps")
+# Initialize the build directory and configure for board:defconfig
+ret = cmake_builder.initialize("sim", "nsh")
+
+# Build using 8 parallel jobs
+cmake_builder.build(parallel=8)
+
+# Clean build artifacts (note: no distclean on CMakeBuilder)
+cmake_builder.clean()
+```
+
+## Apply custom options
+ntxbuild allows you to set Kconfig options through the `ConfigManager`.
+
+```python
+from pathlib import Path
+from ntxbuild.build import MakeBuilder
 from ntxbuild.config import ConfigManager
 
 current_dir = Path.cwd()
 
-builder = NuttXBuilder(current_dir, "nuttx", "nuttx-apps")
-setup_result = builder.setup_nuttx("sim", "nsh")
+builder = MakeBuilder(current_dir, "nuttx", "nuttx-apps")
+builder.initialize("sim", "nsh")
 
 config = ConfigManager(current_dir)
 config.kconfig_enable("CONFIG_EXAMPLES_MOUNT")
@@ -45,7 +84,6 @@ config.kconfig_set_str("CONFIG_EXAMPLES_HELLO_PROGNAME", "hello_app")
 
 builder.build(parallel=8)
 ```
-
 
 ## Copying `nuttxspace`
 ```python

--- a/docs/source/how_it_works.md
+++ b/docs/source/how_it_works.md
@@ -9,14 +9,30 @@ When `start` option is called, the "environment" is prepared. This means things:
 - The path to the NuttX Application repository is also added to the env file
 - The build tool is added to the env file (Make or CMake)
 
+Also, the `start` option supports CMake based build. By passing `--use-cmake`, the user
+will configure the environment to use CMake instead of Make.
+
 This env file will be used by the tool to locate the repositories.
 In the future (as a TO-DO task), the same file could be used to store other information,
 such as out-of-tree repositories and path to toolchains.
 
-Once the environment file is setup, a `NuttXBuilder` instance is created and
+### Makefile based builds
+The default build tool is Make.
+
+Once the environment file is setup, a `MakeBuilder` instance is created and
 it sets up the NuttX environment by checking if the repository is valid
 and finally, executes the `nuttx/tools/configure.sh` script (remember, this tool
 is a wrapper around NuttX).
+
+### CMakeLists based builds
+If the `--use-cmake` option is passed, a `CMakeBuilder` instance is created
+and used instead. Internally, it initializes CMake and uses the `build` directory
+as output and defaults to using the Ninja generator. The operation replicates the
+following command for `sim:nsh`:
+
+```
+cmake -B build -DBOARD_CONFIG=sim:nsh -GNinja
+```
 
 ## Setting KConfig Options
 KConfig options are set through the `ConfigManager` class. When instantiated,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Updates the docs with the new API.
Increases minimal Python version -- does not mean it does not work, just that I don't test on 3.9