### PR TITLE
improvement: allow using ntxbuild from inside Nuttx directory

### DIFF
--- a/ntxbuild/build.py
+++ b/ntxbuild/build.py
@@ -97,6 +97,7 @@ class BaseBuilder(abc.ABC):
         self.no_stdout = False
         self.no_stderr = False
         self.rel_apps_path = None
+        self._build_tool = None
 
         self._validate_nuttx_environment()
         logging.debug(
@@ -123,6 +124,11 @@ class BaseBuilder(abc.ABC):
     @abc.abstractmethod
     def distclean(self) -> subprocess.CompletedProcess:
         ...
+
+    @property
+    def build_tool(self) -> BuildTool:
+        """Get the build tool used by the builder."""
+        return self._build_tool
 
     def supress_stdout(self, enable: bool) -> None:
         """Suppress stdout output from commands.
@@ -222,6 +228,7 @@ class MakeBuilder(BaseBuilder):
             os_dir=os_dir,
             apps_dir=apps_dir,
         )
+        self._build_tool = BuildTool.MAKE
 
     def make(self, command: str) -> subprocess.CompletedProcess:
         """Run any make command inside NuttX directory.
@@ -391,6 +398,7 @@ class CMakeBuilder(BaseBuilder):
             os_dir=os_dir,
             apps_dir=apps_dir,
         )
+        self._build_tool = BuildTool.CMAKE
         self.use_ninja = True
         self.build_dir = self.DEFAULT_BUILD_DIR
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,15 @@ class TestBuild:
         assert result.exit_code == 0
         assert (Path(nuttxspace_path) / "nuttx" / "nuttx").exists()
 
+    def test_build_from_nuttx_directory(self, nuttxspace_path):
+        """Test build command from nuttx directory."""
+        os.chdir(nuttxspace_path / "nuttx")
+
+        runner = CliRunner()
+        result = runner.invoke(build, ["-j4"])
+        assert result.exit_code == 0
+        assert (Path(nuttxspace_path) / "nuttx" / "nuttx").exists()
+
     def test_build_without_ntxenv(self, nuttxspace_path):
         """Test build command fails when .ntxenv doesn't exist."""
         os.chdir(nuttxspace_path)


### PR DESCRIPTION
This PR allows the user to configure and build ntxbuild from either nuttxspace or Nuttx directory.
The logic simply tries to find the `.ntxenv` from the current or parent directory.